### PR TITLE
clarify types for rust/pull/44287

### DIFF
--- a/treeflection_derive/tests/test.rs
+++ b/treeflection_derive/tests/test.rs
@@ -36,7 +36,7 @@ impl Child {
     }
 
     fn function_name(&mut self, value: String) {
-        self.qux += value.parse().unwrap();
+        self.qux += value.parse::<i32>().unwrap();
     }
 
     fn same_name(&self) -> String {


### PR DESCRIPTION
If rust/pull/44287 lands  then [cargobomb](https://github.com/rust-lang/rust/pull/44287#issuecomment-329089956) tells us that this line will have a type ambiguity error, so this is a PR to preemptively prevent that.